### PR TITLE
Fixed Missing CPU Temp in ARM64 (64-bit) Pi OS

### DIFF
--- a/rpi3_conkyrc
+++ b/rpi3_conkyrc
@@ -41,7 +41,7 @@ Uptime $alignr${uptime}
 File System $alignr${fs_type}
 
 ${font Arial:bold:size=10}${color Tan1}CPU ${color DarkSlateGray}${hr 2}
-$font${color DimGray}Temp: $alignr ${exec /opt/vc/bin/vcgencmd measure_temp | cut -c6-9} C
+$font${color DimGray}Temp: $alignr ${exec vcgencmd measure_temp | cut -c6-9} C
 $font${color DimGray}CPU1  ${cpu cpu1}% ${cpubar cpu1}
 CPU2  ${cpu cpu2}% ${cpubar cpu2}
 CPU3  ${cpu cpu3}% ${cpubar cpu3}


### PR DESCRIPTION
Tested on 64-bit Pi OS Buster. ✔

Before:
![image](https://user-images.githubusercontent.com/27908087/147297929-08aaf1cb-4085-4500-a57b-bcca688747ab.png)

After:

![image](https://user-images.githubusercontent.com/27908087/147297735-e47858a7-8a39-433c-80f6-a680c604d87b.png)